### PR TITLE
Исправлено заполнение данных карты в методе платежа

### DIFF
--- a/lib/Model/PaymentMethod/PaymentMethodFactory.php
+++ b/lib/Model/PaymentMethod/PaymentMethodFactory.php
@@ -83,7 +83,19 @@ class PaymentMethodFactory
                 );
             }
         }
+
         $paymentData = $this->factory($type);
+        $this->fillModel($paymentData, $data);
+
+        if ($paymentData instanceof PaymentMethodBankCard && isset($data['card'])) {
+            $this->fillModel($paymentData, $data['card']);
+        }
+
+        return $paymentData;
+    }
+
+    private function fillModel(AbstractPaymentMethod $paymentData, array $data)
+    {
         foreach ($data as $key => $value) {
             if (array_key_exists($key, $this->optionsMap)) {
                 $key = $this->optionsMap[$key];
@@ -92,6 +104,5 @@ class PaymentMethodFactory
                 $paymentData->offsetSet($key, $value);
             }
         }
-        return $paymentData;
     }
 }


### PR DESCRIPTION
Если для оплаты использовать банковскую карту, то в методе платежа `PaymentMethodBankCard`  параметры карты будут пустые. 
Это происходит из-за того, что в свойстве `payment_method` параметры хранятся во вложенном объекте `card`. 
```json
{
    "id":"222948fc-000f-5000-8000-1e0b62b790db",
     ...
    "payment_method":{
        "type":"bank_card",
        "id":"222948fc-000f-5000-8000-1e0b62b790db",
        "saved":true,
        "card":{"last4":"1026","expiry_month":"11","expiry_year":"2020","card_type":"Unknown"},
        "title":"Bank card *1026"
    },
    ...
}
```