### PR TITLE
Убрано поле version из composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
   "name": "yandex-money/yandex-checkout-sdk-php",
-  "version":"1.0.18",
   "license": "MIT",
   "require": {
     "php": ">=5.3.0",

--- a/tests/Client/ClientTest.php
+++ b/tests/Client/ClientTest.php
@@ -1150,13 +1150,6 @@ class ClientTest extends TestCase
         self::assertEquals("general_decline", $response->getCancellationDetails()->getReason());
     }
 
-    public function testSdkVersion()
-    {
-        $composerJsonFile = dirname(__FILE__) . '/../../composer.json';
-        $data = json_decode(file_get_contents($composerJsonFile));
-        self::assertEquals($data->version, Client::SDK_VERSION);
-    }
-
     /**
      * @return PHPUnit_Framework_MockObject_MockObject
      */


### PR DESCRIPTION
Согласно [документации](https://getcomposer.org/doc/04-schema.md#version) оно не нужно и, более того, является причиной для недоразумений из-за человеческих ошибок. Packagist видит версию из тэга, ему это поле не нужно вообще.

Об этом же говорит `composer validate`:

```
./composer.json is valid for simple usage with composer but has
strict errors that make it unable to be published as a package:
See https://getcomposer.org/doc/04-schema.md for details on the schema
description : The property description is required
The version field is present, it is recommended to leave it out if the package is published on Packagist.
```