### PR TITLE
BaseClient: повторять запросы следует и для кода 500

### DIFF
--- a/lib/Client/BaseClient.php
+++ b/lib/Client/BaseClient.php
@@ -369,7 +369,7 @@ class BaseClient
         $attempts = $this->attempts;
         $response = $this->apiClient->call($path, $method, $queryParams, $httpBody, $headers);
 
-        while ($response->getCode() == 202 && $attempts > 0) {
+        while (in_array($response->getCode(), [202, 500]) && $attempts > 0) {
             $this->delay($response);
             $attempts--;
             $response = $this->apiClient->call($path, $method, $queryParams, $httpBody, $headers);


### PR DESCRIPTION
Код 202 в документации вообще не упоминается. [Код 500 упоминается в этом же контексте:](https://kassa.yandex.ru/developers/using-api/basics#http-codes)

> Технические неполадки на стороне Яндекс.Кассы. Результат обработки запроса неизвестен. Повторите запрос позднее с тем же ключом идемпотентности.

На вопрос в поддержку в ответе прямо говорится что 500 код соответствует по смыслу 202 коду, обработка не завершена:

> 500 вернули, так как не успели обработать запрос. Если вы получили 500 статус, необходимо повторить запрос позднее с тем же ключом идемпотентности.

Запрос 21193571.