### PR TITLE
AbstractPaymentMethod::getTitle() can return `null`

### DIFF
--- a/lib/Model/PaymentMethod/AbstractPaymentMethod.php
+++ b/lib/Model/PaymentMethod/AbstractPaymentMethod.php
@@ -139,7 +139,7 @@ abstract class AbstractPaymentMethod extends AbstractObject
     }
 
     /**
-     * @return string Название метода оплаты
+     * @return string|null Название метода оплаты
      */
     public function getTitle()
     {


### PR DESCRIPTION
Метод `AbstractPaymentMethod::getTitle()` на самом деле может в некоторых случаях возвращать `null`