### PR TITLE
Добавлены новые параметры для PaymentMethodBankCard. Исправлен баг с …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v1.6.1 от 26.05.2020
+* Добавлены новые параметры для PaymentMethodBankCard
+* Исправлен баг с serialized receipt, когда параметры 'product_code', 'excise', 'customs_declaration_number', 'country_of_origin_code' не попадали в запрос
+
 ### v1.6.0 от 21.05.2020
 * Добавлено сплитование
 * Исправлен баг в нормализации чека

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -92,7 +92,7 @@ class Client extends BaseClient
     /**
      * Текущая версия библиотеки
      */
-    const SDK_VERSION = '1.6.0';
+    const SDK_VERSION = '1.6.1';
 
     /**
      * Получить список платежей магазина.

--- a/lib/Model/PaymentMethod/BankCardSource.php
+++ b/lib/Model/PaymentMethod/BankCardSource.php
@@ -1,0 +1,26 @@
+<?php
+
+
+namespace YandexCheckout\Model\PaymentMethod;
+
+
+use YandexCheckout\Common\AbstractEnum;
+
+/**
+ * BankCardSource - Источник данных банковской карты
+ * |Код|Описание|
+ * --- | ---
+ * |apple_pay|Источник данных apple_pay|
+ * |google_pay|Источник данных google_pay|
+ *
+ */
+class BankCardSource extends AbstractEnum
+{
+    const APPLE_PAY  = 'apple_pay';
+    const GOOGLE_PAY = 'google_pay';
+
+    protected static $validValues = array(
+        self::APPLE_PAY  => true,
+        self::GOOGLE_PAY => true,
+    );
+}

--- a/lib/Model/PaymentMethod/PaymentMethodBankCard.php
+++ b/lib/Model/PaymentMethod/PaymentMethodBankCard.php
@@ -44,9 +44,19 @@ use YandexCheckout\Model\PaymentMethodType;
  * @property string $expiry_month Срок действия, месяц
  * @property string $cardType Тип банковской карты
  * @property string $card_type Тип банковской карты
+ * @property string $issuerCountry Тип банковской карты
+ * @property string $issuer_country Тип банковской карты
+ * @property string issuerName Тип банковской карты
+ * @property string $issuer_name Тип банковской карты
+ * @property string $source Тип банковской карты
  */
 class PaymentMethodBankCard extends AbstractPaymentMethod
 {
+    /**
+     * @var string Длина кода страны по ISO 3166 https://www.iso.org/obp/ui/#iso:pub:PUB500001:en
+     */
+    const ISO_3166_CODE_LENGTH = 2;
+
     /**
      * @var string Последние 4 цифры номера карты
      */
@@ -71,6 +81,21 @@ class PaymentMethodBankCard extends AbstractPaymentMethod
      * @var string Тип банковской карты
      */
     private $_cardType;
+
+    /**
+     * @var string Код страны, в которой выпущена карта
+     */
+    private $_issuerCountry;
+
+    /**
+     * @var string Наименование банка, выпустившего карту
+     */
+    private $_issuerName;
+
+    /**
+     * @var string Источник данных банковской карты
+     */
+    private $_source;
 
     public function __construct()
     {
@@ -234,5 +259,85 @@ class PaymentMethodBankCard extends AbstractPaymentMethod
                 'Invalid cardType value type', 0, 'PaymentMethodBankCard.cardType', $value
             );
         }
+    }
+
+    /**
+     * @return string
+     */
+    public function getIssuerCountry()
+    {
+        return $this->_issuerCountry;
+    }
+
+    /**
+     * @param string $value
+     */
+    public function setIssuerCountry($value)
+    {
+        if ($value === null || $value === '') {
+            $this->_issuerCountry = (string)$value;
+        } elseif (!TypeCast::canCastToString($value)) {
+            throw new InvalidPropertyValueTypeException(
+                'Invalid issuerCountry value type', 0, 'PaymentMethodBankCard.issuerCountry', $value
+            );
+        } elseif (strlen($value) !== self::ISO_3166_CODE_LENGTH) {
+            throw new InvalidPropertyValueException(
+                'Invalid issuerCountry value', 0, 'PaymentMethodBankCard.issuerCountry', $value
+            );
+        }
+
+        $this->_issuerCountry = (string)$value;
+    }
+
+    /**
+     * @param string $value
+     */
+    public function setIssuerName($value)
+    {
+        if ($value === null || $value === '') {
+            $this->_issuerName = (string)$value;
+        } elseif (!TypeCast::canCastToString($value)) {
+            throw new EmptyPropertyValueException(
+                'Empty issuerName value', 0, 'PaymentMethodBankCard.issuerName'
+            );
+        }
+
+        $this->_issuerName = (string)$value;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIssuerName()
+    {
+        return $this->_issuerName;
+    }
+
+    /**
+     * @param string $value
+     */
+    public function setSource($value)
+    {
+        if ($value === null || $value === '') {
+            $this->_source = (string)$value;
+        } elseif (!TypeCast::canCastToEnumString($value)) {
+            throw new InvalidPropertyValueTypeException(
+                'Invalid source value type', 0, 'PaymentMethodBankCard.source', $value
+            );
+        } elseif (!BankCardSource::valueExists($value)) {
+            throw new InvalidPropertyValueException(
+                'Invalid source value', 0, 'PaymentMethodBankCard.source', $value
+            );
+        }
+
+        $this->_source = (string)$value;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSource()
+    {
+        return $this->_source;
     }
 }

--- a/lib/Request/Payments/Payment/CreateCaptureRequestSerializer.php
+++ b/lib/Request/Payments/Payment/CreateCaptureRequestSerializer.php
@@ -77,6 +77,22 @@ class CreateCaptureRequestSerializer
                         $itemArray['payment_mode'] = $value;
                     }
 
+                    if ($value = $item->getProductCode()) {
+                        $itemArray['product_code'] = $value;
+                    }
+
+                    if ($value = $item->getCountryOfOriginCode()) {
+                        $itemArray['country_of_origin_code'] = $value;
+                    }
+
+                    if ($value = $item->getCustomsDeclarationNumber()) {
+                        $itemArray['customs_declaration_number'] = $value;
+                    }
+
+                    if ($value = $item->getExcise()) {
+                        $itemArray['excise'] = $value;
+                    }
+
                     $result['receipt']['items'][] = $itemArray;
                 }
 
@@ -86,15 +102,19 @@ class CreateCaptureRequestSerializer
                     if ($value = $customer->getEmail()) {
                         $customerArray['email'] = $value;
                     }
+
                     if ($value = $customer->getPhone()) {
                         $customerArray['phone'] = $value;
                     }
+
                     if ($value = $customer->getFullName()) {
                         $customerArray['full_name'] = $value;
                     }
+
                     if ($value = $customer->getInn()) {
                         $customerArray['inn'] = $value;
                     }
+
                     $result['receipt']['customer'] = $customerArray;
                 }
 

--- a/tests/Model/PaymentMethod/PaymentMethodBankCardTest.php
+++ b/tests/Model/PaymentMethod/PaymentMethodBankCardTest.php
@@ -4,6 +4,7 @@ namespace Tests\YandexCheckout\Model\PaymentMethod;
 
 use YandexCheckout\Helpers\Random;
 use YandexCheckout\Helpers\StringObject;
+use YandexCheckout\Model\PaymentMethod\BankCardSource;
 use YandexCheckout\Model\PaymentMethod\PaymentMethodBankCard;
 use YandexCheckout\Model\PaymentMethodType;
 
@@ -171,6 +172,33 @@ class PaymentMethodBankCardTest extends AbstractPaymentMethodTest
     }
 
     /**
+     * @dataProvider validIssuerCountryDataProvider
+     * @param $value
+     */
+    public function testGetSetIssuerCountry($value)
+    {
+        $this->getAndSetTest($value, 'issuerCountry', 'issuer_country');
+    }
+
+    /**
+     * @dataProvider validIssuerNameDataProvider
+     * @param $value
+     */
+    public function testGetSetIssuerName($value)
+    {
+        $this->getAndSetTest($value, 'issuerName', 'issuer_name');
+    }
+
+    /**
+     * @dataProvider validSourceDataProvider
+     * @param $value
+     */
+    public function testGetSetSource($value)
+    {
+        $this->getAndSetTest($value, 'source', 'source');
+    }
+
+    /**
      * @dataProvider invalidCardTypeDataProvider
      * @expectedException \InvalidArgumentException
      * @param mixed $value
@@ -198,6 +226,86 @@ class PaymentMethodBankCardTest extends AbstractPaymentMethodTest
     public function testSetterInvalidCard_type($value)
     {
         $this->getTestInstance()->card_type = $value;
+    }
+
+    /**
+     * @dataProvider invalidIssuerCountryDataProvider
+     * @expectedException \InvalidArgumentException
+     * @param mixed $value
+     */
+    public function testSetInvalidIssuerCountry($value)
+    {
+        $this->getTestInstance()->setIssuerCountry($value);
+    }
+
+    /**
+     * @dataProvider invalidIssuerCountryDataProvider
+     * @expectedException \InvalidArgumentException
+     * @param mixed $value
+     */
+    public function testSetterInvalidIssuerCountry($value)
+    {
+        $this->getTestInstance()->issuerCountry = $value;
+    }
+
+    /**
+     * @dataProvider invalidIssuerCountryDataProvider
+     * @expectedException \InvalidArgumentException
+     * @param mixed $value
+     */
+    public function testSetterInvalidIssuer_country($value)
+    {
+        $this->getTestInstance()->issuer_country = $value;
+    }
+
+    /**
+     * @dataProvider invalidIssuerNameDataProvider
+     * @expectedException \InvalidArgumentException
+     * @param mixed $value
+     */
+    public function testSetInvalidIssuerName($value)
+    {
+        $this->getTestInstance()->setIssuerName($value);
+    }
+
+    /**
+     * @dataProvider invalidIssuerNameDataProvider
+     * @expectedException \InvalidArgumentException
+     * @param mixed $value
+     */
+    public function testSetterInvalidIssuerName($value)
+    {
+        $this->getTestInstance()->issuerName = $value;
+    }
+
+    /**
+     * @dataProvider invalidIssuerNameDataProvider
+     * @expectedException \InvalidArgumentException
+     * @param mixed $value
+     */
+    public function testSetterInvalidIssuer_name($value)
+    {
+        $this->getTestInstance()->issuer_name = $value;
+    }
+
+    /**
+     * @dataProvider invalidSourceDataProvider
+     * @expectedException \InvalidArgumentException
+     * @param mixed $value
+     */
+    public function testSetInvalidSource($value)
+    {
+        $this->getTestInstance()->setSource($value);
+    }
+
+    /**
+     * @dataProvider invalidSourceDataProvider
+     * @expectedException \InvalidArgumentException
+     * @param mixed $value
+     */
+    public function testSetterInvalidSource($value)
+    {
+        $this->getTestInstance()->source = $value;
     }
 
     /**
@@ -263,6 +371,43 @@ class PaymentMethodBankCardTest extends AbstractPaymentMethodTest
         for ($i = 0; $i < 10; $i++) {
             $result[] = array(Random::str(3, 35));
         }
+
+        return $result;
+    }
+
+    public function validIssuerCountryDataProvider()
+    {
+        return array(
+            array('RU'),
+            array('EN'),
+            array('UK'),
+            array('AU'),
+            array(null),
+            array(''),
+        );
+    }
+
+    public function validIssuerNameDataProvider()
+    {
+        $result = array();
+        for ($i = 0; $i < 10; $i++) {
+            $result[] = array(Random::str(3, 35));
+        }
+        $result[] = array("");
+        $result[] = array(null);
+
+        return $result;
+    }
+
+    public function validSourceDataProvider()
+    {
+        $result = array();
+        foreach (BankCardSource::getValidValues() as $value) {
+            $result[] = array($value);
+        }
+        $result[] = array("");
+        $result[] = array(null);
+
         return $result;
     }
 
@@ -336,6 +481,39 @@ class PaymentMethodBankCardTest extends AbstractPaymentMethodTest
         return array(
             array(''),
             array(null),
+            array(true),
+            array(false),
+            array(array()),
+            array(new \stdClass()),
+        );
+    }
+
+    public function invalidIssuerCountryDataProvider()
+    {
+        return array(
+            array(Random::str(3, 4)),
+            array(true),
+            array(false),
+            array(array()),
+            array(new \stdClass()),
+        );
+    }
+
+    public function invalidIssuerNameDataProvider()
+    {
+        return array(
+            array(true),
+            array(false),
+            array(array()),
+            array(new \stdClass()),
+        );
+    }
+
+    public function invalidSourceDataProvider()
+    {
+        return array(
+            array(Random::str(3, 6)),
+            array(Random::int(1, 2)),
             array(true),
             array(false),
             array(array()),


### PR DESCRIPTION
* Добавлены новые параметры для PaymentMethodBankCard
* Исправлен баг с serialized receipt, когда параметры 'product_code', 'excise', 'customs_declaration_number', 'country_of_origin_code' не попадали в запрос
