### PR TITLE
Обработка статуса платежа expired_on_confirmation

### DIFF
--- a/lib/Model/Notification/NotificationExpiredOnConfirmation.php
+++ b/lib/Model/Notification/NotificationExpiredOnConfirmation.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * The MIT License
+ *
+ * Copyright (c) 2017 NBCO Yandex.Money LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+namespace YandexCheckout\Model\Notification;
+
+use YandexCheckout\Common\Exceptions\EmptyPropertyValueException;
+use YandexCheckout\Common\Exceptions\InvalidPropertyValueException;
+use YandexCheckout\Model\NotificationEventType;
+use YandexCheckout\Model\NotificationType;
+use YandexCheckout\Model\Payment;
+use YandexCheckout\Model\PaymentInterface;
+use YandexCheckout\Request\Payments\PaymentResponse;
+
+/**
+ * Класс объекта, присылаемого API при изменении статуса платежа на "expired_on_confirmation"
+ *
+ *
+ * @package YandexCheckout\Model\Notification
+ *
+ * @property-read PaymentInterface $object Объект с информацией о платеже, который можно подтвердить или отменить
+ */
+class NotificationExpiredOnConfirmation extends AbstractNotification
+{
+    /**
+     *
+     * @var Payment Объект платежа
+     */
+    private $_object;
+
+    /**
+     * Конструктор объекта нотификации о возможности подтверждения платежа
+     *
+     * Инициализирует текущий объект из ассоциативного массива, который просто путём JSON десериализации получен из
+     * тела пришедшего запроса. При конструировании проверяется валидность типа передаваемого уведомления, если
+     * передать уведомление не того типа, будет сгенерировано исключение типа {@link InvalidPropertyValueException}
+     *
+     * @param array $source Ассоциативный массив с информацией о уведомлении
+     *
+     * @throws InvalidPropertyValueException Генерируется если значение типа нотификации или события не равны
+     * "notification" и "payment.expired_on_confirmation" соответственно, что может говорить о том, что переданные в
+     * конструктор данные не являются уведомлением нужного типа.
+     */
+    public function __construct(array $source)
+    {
+        $this->_setType(NotificationType::NOTIFICATION);
+        $this->_setEvent(NotificationEventType::PAYMENT_EXPIRED_ON_CONFIRMATION);
+        if (!empty($source['type'])) {
+            if ($this->getType() !== $source['type']) {
+                throw new InvalidPropertyValueException(
+                    'Invalid value for "type" parameter in Notification', 0, 'notification.type', $source['type']
+                );
+            }
+        }
+        if (!empty($source['event'])) {
+            if ($this->getEvent() !== $source['event']) {
+                throw new InvalidPropertyValueException(
+                    'Invalid value for "event" parameter in Notification', 0, 'notification.event', $source['event']
+                );
+            }
+        }
+        if (empty($source['object'])) {
+            throw new EmptyPropertyValueException('Parameter object in NotificationExpiredOnConfirmation is empty');
+        }
+        $this->_object = new PaymentResponse($source['object']);
+    }
+
+    /**
+     * Возвращает объект с информацией о платеже, уведомление о котором хранится в текущем объекте
+     *
+     * Так как нотификация может быть сгенерирована и поставлена в очередь на отправку гораздо раньше, чем она будет
+     * получена на сайте, то опираться на статус пришедшего платежа не стоит, лучше запросить текущую информацию о
+     * платеже у API.
+     *
+     * @return PaymentInterface Объект с информацией о платеже, который можно подтвердить или отменить
+     */
+    public function getObject()
+    {
+        return $this->_object;
+    }
+}

--- a/lib/Model/Notification/NotificationFactory.php
+++ b/lib/Model/Notification/NotificationFactory.php
@@ -32,10 +32,11 @@ use YandexCheckout\Model\NotificationEventType;
 class NotificationFactory
 {
     private $typeClassMap = array(
-        NotificationEventType::PAYMENT_CANCELED            => 'NotificationCanceled',
-        NotificationEventType::REFUND_SUCCEEDED            => 'NotificationRefundSucceeded',
-        NotificationEventType::PAYMENT_SUCCEEDED           => 'NotificationSucceeded',
-        NotificationEventType::PAYMENT_WAITING_FOR_CAPTURE => 'NotificationWaitingForCapture',
+        NotificationEventType::PAYMENT_CANCELED                => 'NotificationCanceled',
+        NotificationEventType::REFUND_SUCCEEDED                => 'NotificationRefundSucceeded',
+        NotificationEventType::PAYMENT_SUCCEEDED               => 'NotificationSucceeded',
+        NotificationEventType::PAYMENT_WAITING_FOR_CAPTURE     => 'NotificationWaitingForCapture',
+        NotificationEventType::PAYMENT_EXPIRED_ON_CONFIRMATION => 'NotificationExpiredOnConfirmation',
     );
 
     /**

--- a/lib/Model/NotificationEventType.php
+++ b/lib/Model/NotificationEventType.php
@@ -31,14 +31,16 @@ use YandexCheckout\Common\AbstractEnum;
 class NotificationEventType extends AbstractEnum
 {
     const PAYMENT_WAITING_FOR_CAPTURE = 'payment.waiting_for_capture';
+    const PAYMENT_EXPIRED_ON_CONFIRMATION = 'payment.expired_on_confirmation';
     const PAYMENT_SUCCEEDED = 'payment.succeeded';
     const PAYMENT_CANCELED = 'payment.canceled';
     const REFUND_SUCCEEDED = 'refund.succeeded';
 
     protected static $validValues = array(
-        self::PAYMENT_WAITING_FOR_CAPTURE => true,
-        self::PAYMENT_SUCCEEDED           => true,
-        self::PAYMENT_CANCELED            => true,
-        self::REFUND_SUCCEEDED            => true,
+        self::PAYMENT_WAITING_FOR_CAPTURE     => true,
+        self::PAYMENT_EXPIRED_ON_CONFIRMATION => true,
+        self::PAYMENT_SUCCEEDED               => true,
+        self::PAYMENT_CANCELED                => true,
+        self::REFUND_SUCCEEDED                => true,
     );
 }

--- a/lib/Model/PaymentStatus.php
+++ b/lib/Model/PaymentStatus.php
@@ -34,6 +34,7 @@ use YandexCheckout\Common\AbstractEnum;
  * --- | ---
  * |pending|Ожидает оплаты покупателем|
  * |waiting_for_capture|Успешно оплачен покупателем, ожидает подтверждения магазином (capture или aviso)|
+ * |expired_on_confirmation|Просрочено время ожидания подтверждения|
  * |succeeded|Успешно оплачен и подтвержден магазином|
  * |canceled|Неуспех оплаты или отменен магазином (cancel)|
  * 
@@ -42,12 +43,14 @@ class PaymentStatus extends AbstractEnum
 {
     const PENDING = 'pending';
     const WAITING_FOR_CAPTURE = 'waiting_for_capture';
+    const EXPIRED_ON_CONFIRMATION = 'expired_on_confirmation';
     const SUCCEEDED = 'succeeded';
     const CANCELED = 'canceled';
 
     protected static $validValues = array(
         self::PENDING => true,
         self::WAITING_FOR_CAPTURE => true,
+        self::EXPIRED_ON_CONFIRMATION => true,
         self::SUCCEEDED => true,
         self::CANCELED => true,
     );

--- a/lib/Model/TransferStatus.php
+++ b/lib/Model/TransferStatus.php
@@ -35,6 +35,7 @@ use YandexCheckout\Common\AbstractEnum;
  * --- | ---
  * |pending|Ожидает оплаты покупателем|
  * |waiting_for_capture|Успешно оплачен покупателем, ожидает подтверждения магазином (capture или aviso)|
+ * |expired_on_confirmation|Просрочено время ожидания подтверждения|
  * |succeeded|Успешно оплачен и получен магазином|
  * |canceled|Неуспех оплаты или отменен магазином (cancel)|
  *
@@ -43,12 +44,14 @@ class TransferStatus extends AbstractEnum
 {
     const PENDING = 'pending';
     const WAITING_FOR_CAPTURE = 'waiting_for_capture';
+    const EXPIRED_ON_CONFIRMATION = 'expired_on_confirmation';
     const SUCCEEDED = 'succeeded';
     const CANCELED = 'canceled';
 
     protected static $validValues = array(
         self::PENDING => true,
         self::WAITING_FOR_CAPTURE => true,
+        self::EXPIRED_ON_CONFIRMATION => true,
         self::SUCCEEDED => true,
         self::CANCELED => true,
     );

--- a/tests/Model/Notification/NotificationExpiredOnConfirmationTest.php
+++ b/tests/Model/Notification/NotificationExpiredOnConfirmationTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Model\Notification;
+
+use Tests\Model\Notification\AbstractNotificationTest;
+use YandexCheckout\Helpers\Random;
+use YandexCheckout\Model\ConfirmationType;
+use YandexCheckout\Model\CurrencyCode;
+use YandexCheckout\Model\Notification\NotificationExpiredOnConfirmation;
+use YandexCheckout\Model\NotificationEventType;
+use YandexCheckout\Model\NotificationType;
+use YandexCheckout\Model\PaymentInterface;
+use YandexCheckout\Model\PaymentMethodType;
+use YandexCheckout\Model\ReceiptRegistrationStatus;
+use YandexCheckout\Model\PaymentStatus;
+
+class NotificationExpiredOnConfirmationTest extends AbstractNotificationTest
+{
+    /**
+     * @param array $source
+     * @return NotificationExpiredOnConfirmation
+     */
+    protected function getTestInstance(array $source)
+    {
+        return new NotificationExpiredOnConfirmation($source);
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedType()
+    {
+        return NotificationType::NOTIFICATION;
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedEvent()
+    {
+        return NotificationEventType::PAYMENT_EXPIRED_ON_CONFIRMATION;
+    }
+
+    /**
+     * @dataProvider validDataProvider
+     * @param array $value
+     */
+    public function testGetObject(array $value)
+    {
+        $instance = $this->getTestInstance($value);
+        self::assertTrue($instance->getObject() instanceof PaymentInterface);
+        self::assertEquals($value['object']['id'], $instance->getObject()->getId());
+    }
+
+    public function validDataProvider()
+    {
+        $result = array();
+        $statuses = PaymentStatus::getValidValues();
+        $receiptRegistrations = ReceiptRegistrationStatus::getValidValues();
+
+        $confirmations = array(
+            array(
+                'type' => ConfirmationType::REDIRECT,
+                'confirmation_url' => Random::str(10),
+                'return_url' => Random::str(10),
+                'enforce' => false,
+            ),
+            array(
+                'type' => ConfirmationType::EXTERNAL,
+            ),
+        );
+
+        for ($i = 0; $i < 10; $i++) {
+            $payment = array(
+                'id' => Random::str(36),
+                'status' => Random::value($statuses),
+                'recipient' => array(
+                    'account_id' => Random::str(1, 64, '0123456789'),
+                    'gateway_id' => Random::str(1, 256),
+                ),
+                'amount' => array(
+                    'value' => Random::float(0.01, 1000000.0),
+                    'currency' => Random::value(CurrencyCode::getValidValues()),
+                ),
+                'payment_method' => array(
+                    'type' => PaymentMethodType::QIWI,
+                ),
+                'created_at' => date(DATE_ATOM, Random::int(1, time())),
+                'captured_at' => date(DATE_ATOM, Random::int(1, time())),
+                'confirmation' => Random::value($confirmations),
+                'refunded' => array(
+                    'value' => Random::float(0.01, 1000000.0),
+                    'currency' => Random::value(CurrencyCode::getValidValues()),
+                ),
+                'paid' => $i % 2 ? true : false,
+                'refundable' => $i % 2 ? true : false,
+                'receipt_registration' => Random::value($receiptRegistrations),
+                'metadata' => array(
+                    'value' => Random::float(0.01, 1000000.0),
+                    'currency' => Random::str(1, 256),
+                ),
+            );
+            $result[] = array(
+                array(
+                    'type' => $this->getExpectedType(),
+                    'event' => $this->getExpectedEvent(),
+                    'object' => $payment,
+                ),
+            );
+        }
+        return $result;
+    }
+}

--- a/tests/Model/Notification/NotificationFactoryTest.php
+++ b/tests/Model/Notification/NotificationFactoryTest.php
@@ -204,6 +204,7 @@ class NotificationFactoryTest extends TestCase
                 break;
             case NotificationEventType::PAYMENT_SUCCEEDED:
             case NotificationEventType::PAYMENT_WAITING_FOR_CAPTURE:
+            case NotificationEventType::PAYMENT_EXPIRED_ON_CONFIRMATION:
             case NotificationEventType::PAYMENT_CANCELED:
                 self::assertTrue($object instanceof PaymentResponse);
                 self::assertEquals($object, new PaymentResponse($value));

--- a/tests/Model/TransferTest.php
+++ b/tests/Model/TransferTest.php
@@ -253,6 +253,7 @@ class TransferTest extends TestCase
             array(TransferStatus::SUCCEEDED),
             array(TransferStatus::CANCELED),
             array(TransferStatus::WAITING_FOR_CAPTURE),
+            array(TransferStatus::EXPIRED_ON_CONFIRMATION),
             array(TransferStatus::PENDING),
         );
     }

--- a/tests/Model/Webhook/WebhookTest.php
+++ b/tests/Model/Webhook/WebhookTest.php
@@ -66,6 +66,13 @@ class WebhookTest extends TestCase
                     "url"   => Random::str(20),
                 ),
             ),
+            array(
+                array(
+                    "id"    => Random::str(20),
+                    "event" => NotificationEventType::PAYMENT_EXPIRED_ON_CONFIRMATION,
+                    "url"   => Random::str(20),
+                ),
+            ),
         );
     }
 }


### PR DESCRIPTION
"Пользователь может подтвердить платеж только за определенный срок. Если он не сделает этого, Яндекс.Касса отменит платеж, указав причину expired_on_confirmation" 

https://kassa.yandex.ru/developers/payments/payment-process

Этот статус довольно часто встречается при проверке текущего статуса транзакции, поскольку клиенты переходят на форму оплаты и не завершают платеж по разным причинам (например недостаток средств на карте).